### PR TITLE
Update baseurl

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # hostname (and path) to the root eg. http://spf13.com/
-baseurl = "http://enten.fr/hugo-boilerplate/"
+baseurl = "https://enten.github.io/hugo-boilerplate/"
 
 # Site title
 title = "sitename"


### PR DESCRIPTION
The demo site URL is https://enten.github.io/hugo-boilerplate/, but config.toml still uses an old version, which gives mixed content warnings and fails to load CSS and other static files.